### PR TITLE
Use sigemptyset to clear the signal set in tcap_scr_main

### DIFF
--- a/src/tcap_scr.c
+++ b/src/tcap_scr.c
@@ -309,7 +309,7 @@ char	*argv[];
     {
 	struct sigaction act;
 	act.sa_handler = win_sig_handler;
-	act.sa_mask = 0;
+	sigemptyset(&act.sa_mask);
 	act.sa_flags = 0;
 	sigaction(SIGWINCH, &act, NULL);
     }


### PR DESCRIPTION
Fixes compilation on Ubuntu 16.04, which would otherwise complain
about assigning an int to sa_mask.
