### PR TITLE
Add ^C and ESC handling for cmdmode cancel and change filename completion to TAB character.

### DIFF
--- a/src/cmdmode.c
+++ b/src/cmdmode.c
@@ -175,7 +175,7 @@ int	ch;
 	    update_cline(win,colposn[inpos]);
 	    return(cmd_INCOMPLETE);
 
-	case ESC:
+	case '\t':
 	{
 	    char	*to_expand;
 	    char	*expansion;
@@ -226,6 +226,13 @@ int	ch;
 	    (void) flexaddch(&win->w_statusline, inbuf[0]);
 	    update_cline(win, colposn[inpos]);
 	    return(cmd_INCOMPLETE);
+
+	case ESC:
+	    inpos = 0; inend = 0;
+	    flexclear(&win->w_statusline);
+	    update_cline(win, colposn[inpos]);
+	    State = NORMAL;
+	    return(cmd_CANCEL);
 
 	/* Simple line editing */
 

--- a/src/events.c
+++ b/src/events.c
@@ -93,6 +93,9 @@ xvEvent	*ev;
     case Ev_breakin:
 	if (State == DISPLAY) {
 	    map_char(CTRL('C'));
+	} else if (State == CMDLINE) {
+	    cmd_input(curwin, ESC);
+	    show_file_info(curwin, TRUE);
 	} else {
 	    /*
 	     * We don't have to handle this any better; any code


### PR DESCRIPTION
This pr makes two changes. First, it adds a check for keyboard input in kbgetc(); this prevents read() from blocking. Second, it adds ^C handling for CMDLINE mode to xvi_handle_event().