### PR TITLE
Adjust ^C handling in normal and commandline modes

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -256,7 +256,11 @@ int	c;
 	/*
 	 * Put the status line back as it should be.
 	 */
-	show_file_info(curwin, TRUE);
+	if (c == CTRL('C')) {
+	    show_message(curwin, "Interrupted");
+	} else {
+	    info_update(curwin);
+	}
 	retval = TRUE;
 	break;
 

--- a/src/movement.c
+++ b/src/movement.c
@@ -312,8 +312,7 @@ int	index;
     oldline = p->p_line;
     p->p_line = lp;
     p->p_index = index;
-    if (oldline != lp)
-	info_update(win);
+    info_update(win);
 }
 
 /*
@@ -347,12 +346,12 @@ int		halfwinsize;
     xvUpdateAllBufferWindows(win->w_buffer);
 
     /*
-     * The result of calling show_file_info here is that if the
+     * The result of calling info_update here is that if the
      * cursor moves a long away - e.g. for a "G" command or a search
      * - the status line is updated with the correct line number.
      * This is a small cost compared to updating the whole window.
      */
-    show_file_info(win, TRUE);
+    info_update(win);
 }
 
 /*

--- a/src/normal.c
+++ b/src/normal.c
@@ -42,6 +42,20 @@ register int	c;
 
     cmd = curwin->w_cmd;
 
+    if (cmd->cmd_prenum != 0) {
+    	if (c == ESC) {
+	    cmd->cmd_operator = NOP;
+	    cmd->cmd_prenum = 0;
+	    return(FALSE);
+    	}
+    	if (c == CTRL('C')) {
+	    cmd->cmd_operator = NOP;
+	    show_message(curwin, "Interrupted");
+	    cmd->cmd_prenum = 0;
+	    return(TRUE);
+	}
+    }
+
     /*
      * If the character is a digit, and it is not a leading '0',
      * compute cmd->cmd_prenum instead of doing a command.  Leading


### PR DESCRIPTION
The "Interrupted" message was not being displayed for cancelled
commandlines; added.

The info line was not always updated with cursor movement unless
the line number changed, causing the "Interrupted" message
to remain longer than relevant; adjusted.

Number prefixes to normal mode commands were not cancelled with
^C or ESC; fixed.