### PR TITLE
Fixup ESC and ^C handling in normal mode.

### DIFF
--- a/src/cmdmode.c
+++ b/src/cmdmode.c
@@ -115,6 +115,11 @@ int	ch;
     unsigned		len;
     char *		stat; /* Pointer to status line text */
 
+    if (kbdintr) {
+	    kbdintr = FALSE;
+	    ch = CTRL('C');
+    }
+
     if (!literal_next) {
 	switch (ch) {
 	case CTRL('V'):

--- a/src/edit.c
+++ b/src/edit.c
@@ -73,6 +73,11 @@ int	c;
 
     curpos = curwin->w_cursor;
 
+    if (kbdintr) {
+	    kbdintr = FALSE;
+	    c = CTRL('C');
+    }
+
     if (wait_buffer || (!literal_next && c == CTRL('A'))) {
 	/*
 	 * Add contents of named buffer, or the last
@@ -468,6 +473,11 @@ int	c;
     static bool_t	wait_buffer = FALSE;
 
     curpos = curwin->w_cursor;
+
+    if (kbdintr) {
+	    kbdintr = FALSE;
+	    c = CTRL('C');
+    }
 
     if (wait_buffer || (!literal_next && c == CTRL('A'))) {
 	/*

--- a/src/events.c
+++ b/src/events.c
@@ -36,6 +36,12 @@ xvEvent	*ev;
     bool_t		do_update;
     int			c;
 
+    if (kbdintr) {
+	    ev->ev_type = Ev_breakin;
+	    ev->ev_inchar = CTRL('C');
+	    kbdintr = FALSE;
+    }
+
     switch (ev->ev_type) {
     case Ev_char:
 	keystrokes++;

--- a/src/normal.c
+++ b/src/normal.c
@@ -43,6 +43,11 @@ register int	c;
 
     cmd = curwin->w_cmd;
 
+    if (kbdintr) {
+	kbdintr = FALSE;
+	c = CTRL('C');
+    }
+
     switch (c) {
 	case CTRL('C'):
 	    show_message(curwin, "Interrupted");

--- a/src/normal.c
+++ b/src/normal.c
@@ -39,21 +39,20 @@ normal(c)
 register int	c;
 {
     register Cmd	*cmd;
+    int ret = FALSE;
 
     cmd = curwin->w_cmd;
 
-    if (cmd->cmd_prenum != 0) {
-    	if (c == ESC) {
-	    cmd->cmd_operator = NOP;
-	    cmd->cmd_prenum = 0;
-	    return(FALSE);
-    	}
-    	if (c == CTRL('C')) {
-	    cmd->cmd_operator = NOP;
+    switch (c) {
+	case CTRL('C'):
 	    show_message(curwin, "Interrupted");
+	    ret = TRUE;
+	case ESC:
+	    cmd->cmd_operator = NOP;
 	    cmd->cmd_prenum = 0;
-	    return(TRUE);
-	}
+	    return(ret);
+	default:
+	    break;
     }
 
     /*
@@ -111,27 +110,6 @@ register int	c;
 
 	State = NORMAL;
 	cmd->cmd_two_char = FALSE;
-
-	/*
-	 * This seems to be a universal rule - if a two-character
-	 * command has ESC as the second character, it means "abort".
-	 */
-	if (cmd->cmd_ch2 == ESC) {
-	    cmd->cmd_operator = NOP;
-	    cmd->cmd_prenum = 0;
-	    return(FALSE);
-	}
-
-	/*
-	 * Abort on ^C, also.
-	 */
-	if (cmd->cmd_ch2 == CTRL('C')) {
-	    cmd->cmd_operator = NOP;
-	    cmd->cmd_prenum = 0;
-	    show_message(curwin, "Interrupted");
-	    return(TRUE);
-	}
-
     } else {
 
 	cmd->cmd_ch1 = c;

--- a/src/unix.c
+++ b/src/unix.c
@@ -233,10 +233,8 @@ kbgetc()
             retval = select(1, &rfds, NULL, NULL, &tv);
             if (retval > 0)
                  break;
-            if (retval == 0)
+            if (retval == 0 || kbdintr)
                 return EOF;
-            if (errno == EINTR)
-                continue;
         }
 
 	if ((nread = read(0, (char *) kbuf, sizeof kbuf)) <= 0) {


### PR DESCRIPTION
This should take care of normal mode ESC and ^C stuff I missed before. I thought I had tested previous changes well enough. Apparently not. Hopefully, this change should cover #19.