### PR TITLE
Fixes for issue #42

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -404,11 +404,10 @@ bool_t	flag;
 				    (int) (curs_row + w->w_winpos),
 				    (long) lineno(w->w_buffer, currline));
 	    if (flag) {
-		nlines = w->w_nrows - curs_row;
+		nlines = w->w_nrows - curs_row - 1;
 		file_to_new(w);
 	    }
 
-	    update_sline(w);
 	    xvUpdateScr(w, w->w_vs, (int) (curs_row + w->w_winpos), nlines);
 	}
 	w = xvNextDisplayedWindow(w);

--- a/src/windows.c
+++ b/src/windows.c
@@ -519,7 +519,7 @@ bool_t	do_clear;
 		to_go -= w->w_nrows;
 		spare -= (w->w_nrows - Pn(P_minrows));
 	    	w->w_nrows = 0;
-		if (curwin == w) {
+		if (curwin == w && w->w_last) {
 		    curwin = w->w_last;
 		}
 	    } else {

--- a/src/windows.c
+++ b/src/windows.c
@@ -478,6 +478,13 @@ bool_t	do_clear;
     }
     last_win = w;
 
+    if (first_win == last_win) {
+	w->w_nrows = VSrows(vs);
+	w->w_ncols = VScols(vs);
+	w->w_cmdline = w->w_nrows + w->w_winpos - 1;
+	return;
+    }
+
     /*
      * Count the total line usage, and at the same time
      * go to the bottom-most window onto the VirtScr.


### PR DESCRIPTION
When resizing windows due to reduction of screen size, if the
screen size is smaller than the set minimum, then
xvAdjustWindows tries to set the curwin to the last window...
add a check that the last window (other than current window)
is valid before assigning it to curwin.