### PR TITLE
Account for statusline when updating lines.

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -404,11 +404,10 @@ bool_t	flag;
 				    (int) (curs_row + w->w_winpos),
 				    (long) lineno(w->w_buffer, currline));
 	    if (flag) {
-		nlines = w->w_nrows - curs_row;
+		nlines = (w->w_nrows - curs_row) - 1;
 		file_to_new(w);
 	    }
 
-	    update_sline(w);
 	    xvUpdateScr(w, w->w_vs, (int) (curs_row + w->w_winpos), nlines);
 	}
 	w = xvNextDisplayedWindow(w);


### PR DESCRIPTION
When I modified the updateline routine to update associated
buffer windows and also to update lines after the specified line,
I forgot to account for the status line. I noticed the statusline
corruption and mistakenly added an update_sline call instead of
subtracting the statusline from the count of lines to be updated.