### PR TITLE
General cleanup

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -136,17 +136,70 @@ challoc()
     return (Change *) ralloc();
 }
 
-char *
+void *
 alloc(size)
-unsigned size;
+size_t size;
 {
-    char *p;		/* pointer to new storage space */
+    void *p;		/* pointer to new storage space */
 
     if ((p = malloc(size)) == NULL) {
 	if (echo & e_ALLOCFAIL) {
 	    show_error(curwin, "Not enough memory!");
 	}
     }
+    return(p);
+}
+
+void *
+re_alloc(ref, size)
+void *ref;
+size_t size;
+{
+    void *p;		/* pointer to new storage space */
+
+    if (ref == NULL) {
+	return(alloc(size));
+    }
+
+    if ((p = realloc(ref, size)) == NULL) {
+	if (echo & e_ALLOCFAIL) {
+	    show_error(curwin, "Not enough memory!");
+	}
+    }
+    return(p);
+}
+
+void *
+clr_alloc(num, size)
+size_t num, size;
+{
+    void *p;		/* pointer to new storage space */
+#if 0
+    size_t total;	/* total size to allocate */
+
+    total = num * size;
+    if ((size != 0) && ((total / size) != num)) {
+	/* overflow */
+	if (echo & e_ALLOCFAIL) {
+	    show_error(curwin, "Allocation size overflow!");
+	}
+	return(NULL);
+    }
+
+    if ((p = malloc(total)) == NULL) {
+	if (echo & e_ALLOCFAIL) {
+	    show_error(curwin, "Not enough memory!");
+	}
+    } else {
+	memset(p, 0, total);
+    }
+#else
+    if ((p = calloc(num, size)) == NULL) {
+	if (echo & e_ALLOCFAIL) {
+	    show_error(curwin, "Not enough memory!");
+	}
+    }
+#endif
     return(p);
 }
 

--- a/src/buffers.c
+++ b/src/buffers.c
@@ -29,18 +29,18 @@ static	bool_t	setup_buffer P((Buffer *));
 Buffer *
 new_buffer()
 {
-    Buffer	*new;
+    Buffer	*newbuf;
 
-    new = (Buffer *) alloc(sizeof(Buffer));
-    if (new == NULL) {
+    newbuf = alloc(sizeof(Buffer));
+    if (newbuf == NULL) {
 	return(NULL);
     }
 
     /*
      * Allocate memory for lines etc.
      */
-    if (setup_buffer(new) == FALSE) {
-	free((char *) new);
+    if (setup_buffer(newbuf) == FALSE) {
+	free(newbuf);
 	return(NULL);
     }
 
@@ -48,12 +48,12 @@ new_buffer()
      * Since setup_buffer() does not set up
      * the filenames, we must do it ourselves.
      */
-    new->b_filename = NULL;
-    new->b_tempfname = NULL;
+    newbuf->b_filename = NULL;
+    newbuf->b_tempfname = NULL;
 
-    new->b_nwindows = 0;
+    newbuf->b_nwindows = 0;
 
-    return(new);
+    return(newbuf);
 }
 
 /*
@@ -76,7 +76,7 @@ Buffer	*buffer;
      */
     free_undo(buffer);
 
-    free((char *) buffer);
+    free(buffer);
 }
 
 /*

--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -857,7 +857,7 @@ bool_t	interactive;			/* true if reading from tty */
     echo = savecho;
 
     if (argc > 0 && argv != NULL) {
-	free((char *) argv);
+	free(argv);
     }
 }
 

--- a/src/ex_cmds1.c
+++ b/src/ex_cmds1.c
@@ -606,7 +606,7 @@ bool_t	force;
 	 * There were no files before, so start from square one.
 	 */
 	if (numfiles == 0) {
-	    files = (char **) alloc((unsigned) argc * sizeof(char *));
+	    files = alloc((unsigned) argc * sizeof(char *));
 	    if (files == NULL) {
 		return;
 	    }
@@ -620,8 +620,7 @@ bool_t	force;
 		free(files[count]);
 	    }
 	    if (argc != numfiles) {
-		files = (char **) realloc((char *) files,
-				    (unsigned) argc * sizeof(char *));
+		files = re_alloc(files, (unsigned) argc * sizeof(char *));
 		if (files == NULL) {
 		    numfiles = 0;
 		    return;
@@ -641,7 +640,7 @@ bool_t	force;
 		 */
 		while (--count >= 0)
 		    free(files[count]);
-		free((char *) files);
+		free(files);
 		files = NULL;
 		numfiles = 0;
 		return;

--- a/src/flexbuf.c
+++ b/src/flexbuf.c
@@ -48,7 +48,7 @@ int	ch;
 	} else {
 	    unsigned newsize = f->fxb_wcnt + FLEXEXTRA;
 
-	    if ((f->fxb_chars = realloc(f->fxb_chars, newsize)) == NULL) {
+	    if ((f->fxb_chars = re_alloc(f->fxb_chars, newsize)) == NULL) {
 		f->fxb_wcnt = f->fxb_max = 0;
 		return FALSE;
 	    } else {
@@ -127,7 +127,7 @@ flexdelete(f)
 Flexbuf	*f;
 {
     if (f->fxb_max > 0) {
-	(void) free(f->fxb_chars);
+	free(f->fxb_chars);
 	f->fxb_wcnt = f->fxb_max = 0;
     }
 }

--- a/src/map.c
+++ b/src/map.c
@@ -502,7 +502,7 @@ char		*rhs;
     Map		**p;			/* used for loop to find position */
     int		rel;
 
-    mptr = (Map *) alloc(sizeof(Map));
+    mptr = alloc(sizeof(Map));
     if (mptr == NULL) {
 	free(lhs);
 	free(rhs);
@@ -526,7 +526,7 @@ char		*rhs;
 	 * We need to replace the rhs of the first map.
 	 */
 	free(lhs);
-	free((char *) mptr);
+	free(mptr);
 	free((*p)->m_rhs);
 	(*p)->m_rhs = rhs;
 	calc_same(*p);
@@ -557,7 +557,7 @@ char		*rhs;
 		     * Replace the old rhs with the new.
 		     */
 		    free(lhs);
-		    free((char *) mptr);
+		    free(mptr);
 		    mptr = (*p)->m_next;
 		    free(mptr->m_rhs);
 		    mptr->m_rhs = rhs;
@@ -617,7 +617,7 @@ char	*lhs;
 		p->m_next = p->m_next->m_next;
 		free(tmp->m_lhs);
 		free(tmp->m_rhs);
-		free((char *) tmp);
+		free(tmp);
 		calc_same(p);
 	    }
 	}

--- a/src/misccmds.c
+++ b/src/misccmds.c
@@ -489,7 +489,7 @@ char	*whites;
     if (*str == '\0')
 	return;
 
-    argv = (char **) alloc(sizeof(char *) * 8);
+    argv = alloc(sizeof(char *) * 8);
     if (argv == NULL)
 	return;
     argv_size = 8;
@@ -498,8 +498,7 @@ char	*whites;
     do {
 	if (argc >= (argv_size - 1)) {
 	    argv_size += 8;
-	    argv = (char **) realloc((char *) argv,
-				(unsigned) argv_size * sizeof(char *));
+	    argv = re_alloc(argv, argv_size * sizeof(char *));
 	    if (argv == NULL)
 		return;
 	}

--- a/src/param.c
+++ b/src/param.c
@@ -832,7 +832,7 @@ void
 		if (pp->p_list[0] != NULL) {
 		    free(pp->p_list[0]);
 		}
-		free((char *) pp->p_list);
+		free(pp->p_list);
 	    }
 	    pp->p_list = argv;
 	}

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -248,7 +248,7 @@ char *exp;
 	FAIL("Regular expression too big");
 
     /* Allocate space. */
-    r = (regexp *) alloc(sizeof(regexp) + (unsigned)regsize);
+    r = alloc(sizeof(regexp) + (unsigned)regsize);
     if (r == NULL)
 	return NULL;
 

--- a/src/search.c
+++ b/src/search.c
@@ -237,10 +237,10 @@ rn_new(str)
 {
     Rnode	*retp;
 
-    if ((retp = (Rnode *) alloc(sizeof (Rnode))) == NULL)
+    if ((retp = alloc(sizeof (Rnode))) == NULL)
 	return NULL;
     if ((retp->rn_ptr = regcomp(str)) == NULL) {
-	free ((char *) retp);
+	free (retp);
 	return NULL;
     }
     retp->rn_count = 1;
@@ -264,8 +264,8 @@ rn_delete(rp)
 Rnode	*rp;
 {
     if (rp != NULL && --rp->rn_count <= 0) {
-	free((char *) rp->rn_ptr);
-	free((char *) rp);
+	free(rp->rn_ptr);
+	free(rp);
     }
 }
 

--- a/src/tags.c
+++ b/src/tags.c
@@ -68,7 +68,7 @@ tagInit()
 	    /*
 	     * Using calloc() avoids having to clear memory.
 	     */
-	    hashtable = (TAG **) calloc(hashtabsize, sizeof(TAG *));
+	    hashtable = clr_alloc(hashtabsize, sizeof(TAG *));
 	    if (hashtable == NULL) {
 		return;
 	    }
@@ -322,7 +322,7 @@ Ev_resize	virtscr.h	/^	Ev_resize,$/;"	e	enum:xvevent::__anon25
      * the text. Then copy the string into the allocated space
      * and set up the pointers within the structure.
      */
-    tp = (TAG *) malloc(sizeof(TAG) + strlen(line) + 1);
+    tp = alloc(sizeof(TAG) + strlen(line) + 1);
     if (tp == NULL) {
 	return;
     }
@@ -471,10 +471,10 @@ tagFree()
 	for (tp = hashtable[count]; tp != NULL; ) {
 	    tmp = tp;
 	    tp = tp->t_next;
-	    free((genptr *) tmp);
+	    free(tmp);
 	}
     }
-    free((genptr *) hashtable);
+    free(hashtable);
     hashtable = NULL;
 }
 

--- a/src/undo.c
+++ b/src/undo.c
@@ -60,20 +60,20 @@ Buffer	*buffer;
     /*
      * Initialise the undo-related variables in the Buffer.
      */
-    cdp = (ChangeData *) alloc(sizeof(ChangeData));
+    cdp = alloc(sizeof(ChangeData));
     if (cdp == NULL) {
     	return;
     }
     cdp->cd_nlevels = 0;
 
-    cdp->cd_undo = (ChangeStack *) alloc(sizeof(ChangeStack));
+    cdp->cd_undo = alloc(sizeof(ChangeStack));
     if (cdp->cd_undo == NULL) {
 	return;
     }
     cdp->cd_undo->cs_stack[0] = NULL;
     cdp->cd_undo->cs_size = 0;
 
-    cdp->cd_redo = (ChangeStack *) alloc(sizeof(ChangeStack));
+    cdp->cd_redo = alloc(sizeof(ChangeStack));
     if (cdp->cd_redo == NULL) {
 	return;
     }

--- a/src/virtscr.c
+++ b/src/virtscr.c
@@ -32,11 +32,12 @@ VirtScr	*vs;
      * Allocate space for the lines. Notice that we allocate an
      * extra byte at the end of each line for null termination.
      */
-    vs->pv_int_lines = (Sline *) malloc(vs->pv_rows * sizeof(Sline));
-    vs->pv_ext_lines = (Sline *) malloc(vs->pv_rows * sizeof(Sline));
-
-    if (vs->pv_int_lines == NULL || vs->pv_ext_lines == NULL) {
-	/* What to do now? */
+    vs->pv_int_lines = alloc(vs->pv_rows * sizeof(Sline));
+    if (vs->pv_int_lines == NULL) {
+	return(FALSE);
+    }
+    vs->pv_ext_lines = alloc(vs->pv_rows * sizeof(Sline));
+    if (vs->pv_ext_lines == NULL) {
 	return(FALSE);
     }
 
@@ -49,12 +50,20 @@ VirtScr	*vs;
 	ip = vs->pv_int_lines + count;
 	ep = vs->pv_ext_lines + count;
 
-    	ip->s_line = malloc((vs->pv_cols + 1) * sizeof(ip->s_line[0]));
-    	ep->s_line = malloc((vs->pv_cols + 1) * sizeof(ip->s_line[0]));
-    	ip->s_colour = malloc((vs->pv_cols + 1) * sizeof(ip->s_colour[0]));
-    	ep->s_colour = malloc((vs->pv_cols + 1) * sizeof(ip->s_colour[0]));
-	if (ip->s_line == NULL || ep->s_line == NULL ||
-		ip->s_colour == NULL || ep->s_colour == NULL) {
+    	ip->s_line = alloc((vs->pv_cols + 1) * sizeof(ip->s_line[0]));
+	if (ip->s_line == NULL) {
+	    return(FALSE);
+	}
+    	ep->s_line = alloc((vs->pv_cols + 1) * sizeof(ip->s_line[0]));
+	if (ep->s_line == NULL) {
+	    return(FALSE);
+	}
+    	ip->s_colour = alloc((vs->pv_cols + 1) * sizeof(ip->s_colour[0]));
+	if (ip->s_colour == NULL) {
+	    return(FALSE);
+	}
+    	ep->s_colour = alloc((vs->pv_cols + 1) * sizeof(ip->s_colour[0]));
+	if (ep->s_colour == NULL) {
 	    return(FALSE);
 	}
 
@@ -93,8 +102,10 @@ int	rows, columns;
      * Free up rows no longer required.
      */
     for (count = new_rows; count < old_rows; count++) {
-	free((genptr *) vs->pv_int_lines[count].s_line);
-	free((genptr *) vs->pv_ext_lines[count].s_line);
+	free(vs->pv_int_lines[count].s_line);
+	free(vs->pv_ext_lines[count].s_line);
+	free(vs->pv_int_lines[count].s_colour);
+	free(vs->pv_ext_lines[count].s_colour);
     }
 
     /*
@@ -102,11 +113,14 @@ int	rows, columns;
      * for new_rows to be 0, we add a single byte to the amount
      * allocated. This ensures that the allocation will succeed.
      */
-    vs->pv_int_lines = (Sline *) realloc((genptr *) vs->pv_int_lines,
-				((unsigned) new_rows * sizeof(Sline)) + 1);
-    vs->pv_ext_lines = (Sline *) realloc((genptr *) vs->pv_ext_lines,
-				((unsigned) new_rows * sizeof(Sline)) + 1);
-    if (vs->pv_int_lines == NULL || vs->pv_ext_lines == NULL) {
+    vs->pv_int_lines = re_alloc(vs->pv_int_lines,
+		    		(new_rows * sizeof(Sline)) + 1);
+    if (vs->pv_int_lines == NULL) {
+    	return(FALSE);
+    }
+    vs->pv_ext_lines = re_alloc(vs->pv_ext_lines,
+				(new_rows * sizeof(Sline)) + 1);
+    if (vs->pv_ext_lines == NULL) {
     	return(FALSE);
     }
 
@@ -117,14 +131,20 @@ int	rows, columns;
 	ip = vs->pv_int_lines + count;
 	ep = vs->pv_ext_lines + count;
 
-	ip->s_line = malloc((unsigned) (new_cols + 1) * sizeof(ip->s_line[0]));
-	ep->s_line = malloc((unsigned) (new_cols + 1) * sizeof(ip->s_line[0]));
-	ip->s_colour = malloc((unsigned)
-				(new_cols + 1) * sizeof(ip->s_colour[0]));
-	ep->s_colour = malloc((unsigned)
-				(new_cols + 1) * sizeof(ip->s_colour[0]));
-	if (ip->s_line == NULL || ep->s_line == NULL ||
-		ip->s_colour == NULL || ep->s_colour == NULL) {
+	ip->s_line = alloc((new_cols + 1) * sizeof(ip->s_line[0]));
+	if (ip->s_line == NULL) {
+	    return(FALSE);
+	}
+	ep->s_line = alloc((new_cols + 1) * sizeof(ip->s_line[0]));
+	if (ep->s_line == NULL) {
+	    return(FALSE);
+	}
+	ip->s_colour = alloc((new_cols + 1) * sizeof(ip->s_colour[0]));
+	if (ip->s_colour == NULL) {
+	    return(FALSE);
+	}
+	ep->s_colour = alloc((new_cols + 1) * sizeof(ip->s_colour[0]));
+	if (ep->s_colour == NULL) {
 	    return(FALSE);
 	}
 
@@ -146,16 +166,24 @@ int	rows, columns;
 	ip = vs->pv_int_lines + count;
 	ep = vs->pv_ext_lines + count;
 
-	ip->s_line = realloc(ip->s_line,
-			(unsigned) (new_cols + 1) * sizeof(ip->s_line[0]));
-	ep->s_line = realloc(ep->s_line,
-			(unsigned) (new_cols + 1) * sizeof(ep->s_line[0]));
-	ip->s_colour = realloc(ip->s_colour,
-			(unsigned) (new_cols + 1) * sizeof(ip->s_colour[0]));
-	ep->s_colour = realloc(ep->s_colour,
-			(unsigned) (new_cols + 1) * sizeof(ep->s_colour[0]));
-	if (ip->s_line == NULL || ep->s_line == NULL ||
-		ip->s_colour == NULL || ep->s_colour == NULL) {
+	ip->s_line = re_alloc(ip->s_line,
+			(new_cols + 1) * sizeof(ip->s_line[0]));
+	if (ip->s_line == NULL) {
+	    return(FALSE);
+	}
+	ep->s_line = re_alloc(ep->s_line,
+			(new_cols + 1) * sizeof(ep->s_line[0]));
+	if (ep->s_line == NULL) {
+	    return(FALSE);
+	}
+	ip->s_colour = re_alloc(ip->s_colour,
+			(new_cols + 1) * sizeof(ip->s_colour[0]));
+	if (ip->s_colour == NULL) {
+	    return(FALSE);
+	}
+	ep->s_colour = re_alloc(ep->s_colour,
+			(new_cols + 1) * sizeof(ep->s_colour[0]));
+	if (ep->s_colour == NULL) {
 	    return(FALSE);
 	}
     }
@@ -173,13 +201,13 @@ VirtScr	*vs;
      * Now delete the memory used for the screen image.
      */
     for (count = 0; count < vs->pv_rows; count++) {
-	free((genptr *) vs->pv_int_lines[count].s_line);
-	free((genptr *) vs->pv_ext_lines[count].s_line);
-	free((genptr *) vs->pv_int_lines[count].s_colour);
-	free((genptr *) vs->pv_ext_lines[count].s_colour);
+	free(vs->pv_int_lines[count].s_line);
+	free(vs->pv_ext_lines[count].s_line);
+	free(vs->pv_int_lines[count].s_colour);
+	free(vs->pv_ext_lines[count].s_colour);
     }
-    free((genptr *) vs->pv_int_lines);
-    free((genptr *) vs->pv_ext_lines);
+    free(vs->pv_int_lines);
+    free(vs->pv_ext_lines);
     VSclose(vs);
 }
 

--- a/src/windows.c
+++ b/src/windows.c
@@ -44,16 +44,16 @@ VirtScr	*vs;
     }
 
     newwin->w_vs = vs;
-    newwin->w_vs->pv_window = (genptr *) newwin;
+    newwin->w_vs->pv_window = newwin;
 
     if (alloc_window(newwin) == FALSE) {
-	free((genptr *) newwin);
+	free(newwin);
 	return(NULL);
     }
 
     if (!vs_init(vs)) {
 	dealloc_window(newwin);
-	free((genptr *) newwin);
+	free(newwin);
 	return(NULL);
     }
 
@@ -645,7 +645,7 @@ Xviwin	*win;
     /*
      * Allocate a Posn structure for the cursor.
      */
-    win->w_cursor = (Posn *) malloc(sizeof(Posn));
+    win->w_cursor = alloc(sizeof(Posn));
     if (win->w_cursor == NULL) {
 	return(FALSE);
     }
@@ -653,7 +653,7 @@ Xviwin	*win;
     win->w_colour_cost = VScolour_cost(vs);
     win->w_spare_cols = 1 + (win->w_colour_cost * 2);
 
-    win->w_cmd = (Cmd *) malloc(sizeof(Cmd));
+    win->w_cmd = alloc(sizeof(Cmd));
     if (win->w_cmd == NULL) {
 	return(FALSE);
     }
@@ -670,8 +670,8 @@ static void
 dealloc_window(win)
 Xviwin	*win;
 {
-    free((genptr *) win->w_cursor);
-    free((genptr *) win->w_cmd);
+    free(win->w_cursor);
+    free(win->w_cmd);
     flexdelete(&win->w_statusline);
 }
 
@@ -692,7 +692,7 @@ Xviwin	*last, *next;
 {
     Xviwin	*newwin;
 
-    newwin = (Xviwin *) malloc(sizeof(Xviwin));
+    newwin = alloc(sizeof(Xviwin));
     if (newwin == NULL) {
 	return(NULL);
     }

--- a/src/xvi.h
+++ b/src/xvi.h
@@ -840,7 +840,9 @@ extern	struct redo	Redo;
 /*
  * alloc.c
  */
-extern	char	*alloc P((unsigned int));
+extern	void	*alloc P((size_t));
+extern	void	*re_alloc P((void *, size_t));
+extern	void	*clr_alloc P((size_t, size_t));
 extern	char	*strsave P((const char *));
 extern	Line	*newline P((int));
 extern	bool_t	lnresize P((Line *, unsigned));

--- a/src/yankput.c
+++ b/src/yankput.c
@@ -511,7 +511,7 @@ Posn	*from, *to;
     char	*cp;
 
     nchars = to->p_index - from->p_index + 1;
-    cp = (char *) alloc((unsigned) nchars + 1);
+    cp = alloc((unsigned) nchars + 1);
     if (cp == NULL) {
 	return(NULL);
     }


### PR DESCRIPTION
I have been itching to make these changes, but was holding myself thinking that the other code I have been working on should take precedence. I am finding myself increasingly tempted to start sneaking some of these in while working on other stuff.

For the larger part, this PR is intended to tidy the usage of dynamic memory routines.

The changes to exChangeDirectory seemed unavoidable, once I had noticed the usage of getenv return value and the "Invalid directory" error message for chdir failure (there are at least six possible reasons for chdir failures, and while five of those could be considered validity, the other is permissions and is probably the most likely error when the path exists).