### PR TITLE
Fixes

### DIFF
--- a/src/param.c
+++ b/src/param.c
@@ -286,6 +286,7 @@ init_params()
      * parameter structures.
      */
     for (i = 0; i < NSTRS; i++) {
+	params[init_str[i].index].p_str = NULL;
 	set_param(init_str[i].index, init_str[i].value);
     }
     for (i = 0; i < NENUMS; i++) {

--- a/src/screen.c
+++ b/src/screen.c
@@ -300,7 +300,8 @@ Xviwin	*win;
 
     if ((win->w_nrows == 0) ||
 	(VSrows(win->w_vs)  == 0) ||
-	(VScols(win->w_vs) == 0)) {
+	(VScols(win->w_vs) == 0) ||
+	(win->w_cmdline > VSrows(win->w_vs))) {
 	return;
     }
 
@@ -447,8 +448,8 @@ bool_t	flag;
     	return;
     }
     if (flag) {
-	xvClear(window->w_vs);
-	update_sline(window);
+	xvClearWindow(window->w_vs, window);
+	do_sline(window);
     }
     if (window->w_nrows > 1) {
 	file_to_new(window);
@@ -482,10 +483,9 @@ bool_t	clrflag;
 		file_to_new(w);
 	    do_sline(w);
 	}
-	w = xvNextDisplayedWindow(w);
-    } while (w != win);
+    } while ((w = xvNextWindow(w)) != win);
 
-    xvUpdateScr(win, win->w_vs, 0, (int) VSrows(win->w_vs));
+    xvUpdateScr(win, win->w_vs, 0, VSrows(win->w_vs));
 }
 
 /*

--- a/src/screen.c
+++ b/src/screen.c
@@ -95,6 +95,16 @@ long		line;
 	    if (curr_index == norm_colour_pos) {
 		colour = VSCcolour;
 	    }
+#if 0
+	    /* This can be an incredible performance hit if there are no
+	     * tags files. In that case, every line that gets refreshed
+	     * will call tagLookup, whick will in turn will call tagInit,
+	     * which will then try to open any files listed in the 'tags'
+	     * param. That will be for every line that is being refreshed!
+	     * Also, bugs in the tags handling can show up when just
+	     * refreshing displayed lines. This needs serious consideration
+	     * before being added back to such a crucial part of the code.
+	     */
 	    if (curr_index == possible_tag) {
 		int	len, offset;
 
@@ -104,7 +114,7 @@ long		line;
 		}
 		possible_tag += offset;
 	    }
-
+#endif
 	    c = (unsigned char) (ltext[curr_index++]);
 
 	    /*

--- a/src/tags.c
+++ b/src/tags.c
@@ -59,7 +59,7 @@ tagInit()
 
     for (count = 0; tagfiles[count] != NULL; count++) {
 
-	fp = fopen(fexpand(tagfiles[count], FALSE), "r");
+	fp = fopen(tagfiles[count], "r");
 	if (fp == NULL) {
 	    continue;
 	}

--- a/src/tcap_scr.c
+++ b/src/tcap_scr.c
@@ -336,11 +336,8 @@ char	*argv[];
 		getScreenSize(&new_rows, &new_cols);
 		if (new_rows != 0 && new_cols != 0) {
 		    event.ev_type = Ev_resize;
-		    event.ev_rows = new_rows - vs->pv_rows;
-		    event.ev_columns = new_cols - vs->pv_cols;
-
-		    vs->pv_rows = LI = new_rows;
-		    vs->pv_cols = CO = new_cols;
+		    event.ev_rows = new_rows;
+		    event.ev_columns = new_cols;
 		} else {
 		    pbeep(vs);
 		    continue;		/* don't process this event */

--- a/src/update.c
+++ b/src/update.c
@@ -287,7 +287,22 @@ unsigned	line;
 {
     vs->pv_ext_lines[line].s_used = 0;
     vs->pv_ext_lines[line].s_line[0] = '\0';
-    xvMarkDirty(vs, (int) line);
+    xvMarkDirty(vs, line);
+}
+
+void
+xvClearWindow(vs, win)
+VirtScr		*vs;
+Xviwin		*win;
+{
+    register unsigned	row;
+    register unsigned	nrows;
+
+    VSset_colour(vs, VSCcolour);
+
+    for (row = 0; row < win->w_nrows; row++) {
+	xvClearLine(vs, win->w_winpos + row);
+    }
 }
 
 void

--- a/src/xvi.h
+++ b/src/xvi.h
@@ -1199,6 +1199,7 @@ extern	bool_t	set_undolevels P((Xviwin *, Paramval, bool_t));
 extern	void	xvUpdateScr P((Xviwin *, VirtScr *, int, int));
 extern	void	xvMarkDirty P((VirtScr *, int));
 extern	void	xvClearLine P((VirtScr *, unsigned));
+extern	void	xvClearWindow P((VirtScr *, Xviwin *));
 extern	void	xvClear P((VirtScr *));
 
 /*


### PR DESCRIPTION
I got a nasty surprise when resizing an xterm containing an running xvi instance; it crashed during the resize. I was cursing myself for missing something in #43. Then, while trying to isolate the new crash, xvi started hanging in the tag code. I was asking myself, 'what the heck does the screen refresh need to do in the tag code?!'. Well, the idea of highlighting tags is kinda cool; but not so much at the performance penalty we are taking, as well as the chances of tag handling bugs disrupting screen refresh (which I feel sure is the case here).  We can eventually track down problems in the tags code, but for now, I think we should revisit highlighting tags later.

I removed the fexpand call from tagInit's attempt to open tag files. I seems similar to what traditional vi does, but seems truly inadvisable when fexpand is shelling out the do the expansion/completion. The fexpand routine really should be rewritten from scratch so that we are doing this operation 'in house'.

Also some other checks and simplifications to help keep the refresh/resize code to a minimum complexity and least likely to bite us in the hind end.