### PR TITLE
Rework CTRL('C') handling.

### DIFF
--- a/src/cmdmode.c
+++ b/src/cmdmode.c
@@ -115,8 +115,8 @@ int	ch;
     unsigned		len;
     char *		stat; /* Pointer to status line text */
 
-    if (kbdintr) {
-	    kbdintr = FALSE;
+    if (kbdintr == KBD_INTR_PENDING) {
+	    kbdintr = KBD_INTR_MESSAGE;
 	    ch = CTRL('C');
     }
 

--- a/src/defscr.c
+++ b/src/defscr.c
@@ -109,9 +109,9 @@ char	*argv[];
 
 	r = inchar(timeout);
 	if (r == EOF) {
-	    if (kbdintr) {
+	    if (kbdintr == KBD_INTR_PENDING) {
 		event.ev_type = Ev_breakin;
-		kbdintr = FALSE;
+		kbdintr = KBD_INTR_MESSAGE;
 	    } else if (SIG_terminate) {
 		event.ev_type = Ev_terminate;
 		SIG_terminate = FALSE;

--- a/src/dispmode.c
+++ b/src/dispmode.c
@@ -68,7 +68,7 @@ int	ch;
 
     vs = win->w_vs;
 
-    if (finished || kbdintr) {
+    if (finished || kbdintr == KBD_INTR_PENDING || ch == CTRL('C')) {
 	/*
 	 * Ensure that the window on the current buffer is
 	 * in the right place; then update the whole window.
@@ -83,9 +83,11 @@ int	ch;
 	    stuff(":");
 	}
 	finished = FALSE;
-	if (kbdintr) {
-	    imessage = TRUE;
+
+	if (kbdintr == KBD_INTR_PENDING) {
+	    kbdintr = KBD_INTR_MESSAGE;
 	}
+
 	return(TRUE);
     }
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -79,8 +79,8 @@ int	c;
      */
     nlines = plines(curwin, curpos->p_line);
 
-    if (kbdintr) {
-	    kbdintr = FALSE;
+    if (kbdintr == KBD_INTR_PENDING) {
+	    kbdintr = KBD_INTR_MESSAGE;
 	    c = CTRL('C');
     }
 
@@ -103,7 +103,6 @@ int	c;
 	 */
 	switch (c) {
 	case CTRL('C'):	/* an escape or ^C ends input mode */
-	    show_message(curwin, "Interrupted");
 	    Ins_repeat = 0;
 	case ESC:
 	{
@@ -470,8 +469,8 @@ int	c;
 
     curpos = curwin->w_cursor;
 
-    if (kbdintr) {
-	    kbdintr = FALSE;
+    if (kbdintr == KBD_INTR_PENDING) {
+	    kbdintr = KBD_INTR_MESSAGE;
 	    c = CTRL('C');
     }
 
@@ -490,7 +489,6 @@ int	c;
     } else if (!literal_next) {
 	switch (c) {
 	case CTRL('C'):			/* an escape or ^C ends input mode */
-	    show_message(curwin, "Interrupted");
 	case ESC:
 	    end_replace(c);
 	    return(TRUE);

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -212,8 +212,8 @@ char	*file;
 		break;
 
 	    case '\n':
-		if (kbdintr) {
-		    imessage = TRUE;
+		if (kbdintr == KBD_INTR_PENDING) {
+		    kbdintr = KBD_INTR_MESSAGE;
 		    break;
 		}
 		if (!flexempty(&cmd)) {

--- a/src/normal.c
+++ b/src/normal.c
@@ -39,25 +39,18 @@ normal(c)
 register int	c;
 {
     register Cmd	*cmd;
-    int ret = FALSE;
 
     cmd = curwin->w_cmd;
 
-    if (kbdintr) {
-	kbdintr = FALSE;
+    if (kbdintr == KBD_INTR_PENDING) {
+	kbdintr = KBD_INTR_MESSAGE;
 	c = CTRL('C');
     }
 
-    switch (c) {
-	case CTRL('C'):
-	    show_message(curwin, "Interrupted");
-	    ret = TRUE;
-	case ESC:
+    if ((c == ESC) || (c == CTRL('C'))) {
 	    cmd->cmd_operator = NOP;
 	    cmd->cmd_prenum = 0;
-	    return(ret);
-	default:
-	    break;
+	    return(FALSE);
     }
 
     /*

--- a/src/pc386.c
+++ b/src/pc386.c
@@ -120,7 +120,7 @@ criterr(int *pax, int *pdi)
 static void _cdecl
 inthandler(void)
 {
-    kbdintr = 1;
+    kbdintr = KBD_INTR_PENDING;
 #if 0
     return(-1);	/* don't chain to previously installed vector */
 #endif

--- a/src/q2tscr.c
+++ b/src/q2tscr.c
@@ -134,9 +134,9 @@ char	*argv[];
 
 	r = inchar(timeout);
 	if (r == EOF) {
-	    if (kbdintr) {
+	    if (kbdintr == KBD_INTR_PENDING) {
 		event.ev_type = Ev_breakin;
-		kbdintr = FALSE;
+		kbdintr = KBD_INTR_MESSAGE;
 	    } else if (SIG_terminate) {
 		event.ev_type = Ev_terminate;
 		SIG_terminate = FALSE;

--- a/src/q2wscr.c
+++ b/src/q2wscr.c
@@ -240,9 +240,9 @@ process_event()
 	 * Assume that if we were interrupted, no event has been received,
 	 * so we can simply process the interrupt and then continue.
 	 */
-	if (kbdintr) {
+	if (kbdintr == KBD_INTR_PENDING) {
 	    event.ev_type = Ev_breakin;
-	    kbdintr = FALSE;
+	    kbdintr = KBD_INTR_MESSAGE;
 	} else if (SIG_terminate) {
 	    event.ev_type = Ev_terminate;
 	    SIG_terminate = FALSE;

--- a/src/screen.c
+++ b/src/screen.c
@@ -418,6 +418,7 @@ bool_t	flag;
 	    }
 
 	    xvUpdateScr(w, w->w_vs, (int) (curs_row + w->w_winpos), nlines);
+	    info_update(w);
 	}
 	w = xvNextDisplayedWindow(w);
     } while (w != window);

--- a/src/signal.c
+++ b/src/signal.c
@@ -133,7 +133,7 @@ int_handler(sig)
 int	sig;
 {
     (void) signal(SIGINT, int_handler);
-    kbdintr = TRUE;
+    kbdintr = KBD_INTR_PENDING;
 }
 #endif
 

--- a/src/startup.c
+++ b/src/startup.c
@@ -43,15 +43,9 @@ unsigned	echo;		/*
 
 int		indentchars;	/* number of chars indented on current line */
 
-volatile unsigned char
-		kbdintr;	/*
-				 * global flag set when a keyboard interrupt
-				 * is received
-				 */
-
-bool_t		imessage;	/*
-				 * global flag to indicate whether we should
-				 * display the "Interrupted" message
+volatile kbd_intr_t kbdintr;	/*
+				 * global state set when a keyboard interrupt
+				 * is pending, awaiting message, or clear.
 				 */
 
 /*

--- a/src/startup.c
+++ b/src/startup.c
@@ -44,8 +44,13 @@ unsigned	echo;		/*
 int		indentchars;	/* number of chars indented on current line */
 
 volatile kbd_intr_t kbdintr;	/*
-				 * global state set when a keyboard interrupt
-				 * is pending, awaiting message, or clear.
+				 * This is the current keyboard interrupt state.
+				 * KBD_INTR_CLEAR: keyboard interrupts have been
+				 * 	completely handled.
+				 * KBD_INTR_PENDING: keyboard interrupt has been
+				 * 	received but no code has acted on it.
+				 * KBD_INTR_MESSAGE: keyboard interrupt has been
+				 * 	acted on but no message has been output.
 				 */
 
 /*

--- a/src/tcap_scr.c
+++ b/src/tcap_scr.c
@@ -316,9 +316,9 @@ char	*argv[];
 
 	r = inch(timeout);
 	if (r == EOF) {
-	    if (kbdintr) {
+	    if (kbdintr == KBD_INTR_PENDING) {
 		event.ev_type = Ev_breakin;
-		kbdintr = FALSE;
+		kbdintr = KBD_INTR_MESSAGE;
 	    } else if (SIG_terminate) {
 		event.ev_type = Ev_terminate;
 		SIG_terminate = FALSE;

--- a/src/unix.c
+++ b/src/unix.c
@@ -216,7 +216,7 @@ kbgetc()
     static unsigned char	kbuf[48];
     static unsigned char	*kbp;
 
-    if (kbdintr == TRUE)
+    if (kbdintr == KBD_INTR_PENDING)
 	return EOF;
 
     if (kb_nchars <= 0) {
@@ -233,7 +233,7 @@ kbgetc()
             retval = select(1, &rfds, NULL, NULL, &tv);
             if (retval > 0)
                  break;
-            if (retval == 0 || kbdintr)
+            if (retval == 0 || kbdintr == KBD_INTR_PENDING)
                 return EOF;
         }
 

--- a/src/xvi.h
+++ b/src/xvi.h
@@ -734,12 +734,14 @@ extern	char		*altfilename;	/* name of current alternate file */
 extern	char		Version[];	/* version string for :ve command */
 
 /*
- * This flag is set when a keyboard interrupt is received.
+ * This variable is set to the current keyboard interrupt state.
  */
 typedef enum kbd_intr_t {
-    KBD_INTR_CLEAR,	/* SIGINT handling is not required */
-    KBD_INTR_PENDING,	/* SIGINT received, requires handling */
-    KBD_INTR_MESSAGE	/* SIGINT handled, but message has not been output */
+    KBD_INTR_CLEAR,	/* keyboard interrupts have been completely handled. */
+    KBD_INTR_PENDING,	/* keyboard interrupt received, but no code has
+			   acted on it yet. */
+    KBD_INTR_MESSAGE	/* keyboard interrupt has been acted on, message has
+			   yet to be output for it. */
 } kbd_intr_t;
 extern volatile kbd_intr_t kbdintr;
 

--- a/src/xvi.h
+++ b/src/xvi.h
@@ -736,13 +736,12 @@ extern	char		Version[];	/* version string for :ve command */
 /*
  * This flag is set when a keyboard interrupt is received.
  */
-extern volatile unsigned char kbdintr;
-
-/*
- * This one indicates whether we should display the "Interrupted"
- * message.
- */
-extern	bool_t		imessage;
+typedef enum kbd_intr_t {
+    KBD_INTR_CLEAR,	/* SIGINT handling is not required */
+    KBD_INTR_PENDING,	/* SIGINT received, requires handling */
+    KBD_INTR_MESSAGE	/* SIGINT handled, but message has not been output */
+} kbd_intr_t;
+extern volatile kbd_intr_t kbdintr;
 
 /*
  * This flag is set when a keyboard-generated suspension request

--- a/src/xwnscr.c
+++ b/src/xwnscr.c
@@ -477,9 +477,9 @@ long		timeout;
 	    /*
 	     * Either a timeout, or some kind of interrupt.
 	     */
-	    if (kbdintr) {
+	    if (kbdintr == KBD_INTR_PENDING) {
 		xvevent->ev_type = Ev_breakin;
-		kbdintr = FALSE;
+		kbdintr = KBD_INTR_MESSAGE;
 	    } else if (SIG_terminate) {
 		xvevent->ev_type = Ev_terminate;
 		SIG_terminate = FALSE;


### PR DESCRIPTION
Previously, the kbdintr variable was a bool type, needing also the
imessage flag to print the 'Interrupted' message. Simplify this by
changing the kbdintr into an enumeration so that we can check for
multiple states and track just the one variable.