### PR TITLE
Remove tag highlighting from line refresh.

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -95,16 +95,7 @@ long		line;
 	    if (curr_index == norm_colour_pos) {
 		colour = VSCcolour;
 	    }
-	    if (curr_index == possible_tag) {
-		int	len, offset;
-
-		if (tagLookup(&ltext[curr_index], &len, &offset) != NULL) {
-		    colour = VSCtagcolour;
-		    norm_colour_pos = curr_index + len;
-		}
-		possible_tag += offset;
-	    }
-
+	    
 	    c = (unsigned char) (ltext[curr_index++]);
 
 	    /*


### PR DESCRIPTION
Looking up tags on every line refresh is a heavy burden on the
screen update code. Remove this feature since it is an
extravagance that costs to much against performance and may
cause bugs in the tag code to affect general screen updates.