### PR TITLE
Increase termcap buffer size.

### DIFF
--- a/src/tcap_scr.c
+++ b/src/tcap_scr.c
@@ -795,7 +795,7 @@ tty_open(prows, pcolumns)
 unsigned int	*prows;
 unsigned int	*pcolumns;
 {
-    char	tcbuf[1024];		/* buffer for termcap entry */
+    char	tcbuf[4096];		/* buffer for termcap entry */
     char	*termtype;		/* terminal type */
     static	char strings[512];	/* space for storing strings */
     char	*strp = strings;	/* ptr to space left in strings */


### PR DESCRIPTION
When built against a real termcap library, the termcap buffer
can overflow if the terminal description is too large. Increase
the buffer size to prevent this.