### PR TITLE
Revisit and revise ^C handling.

### DIFF
--- a/src/cmdmode.c
+++ b/src/cmdmode.c
@@ -117,6 +117,7 @@ int	ch;
 
     if (kbdintr) {
 	    kbdintr = FALSE;
+	    imessage = TRUE;
 	    ch = CTRL('C');
     }
 

--- a/src/defscr.c
+++ b/src/defscr.c
@@ -111,7 +111,6 @@ char	*argv[];
 	if (r == EOF) {
 	    if (kbdintr) {
 		event.ev_type = Ev_breakin;
-		kbdintr = FALSE;
 	    } else if (SIG_terminate) {
 		event.ev_type = Ev_terminate;
 		SIG_terminate = FALSE;

--- a/src/dispmode.c
+++ b/src/dispmode.c
@@ -68,7 +68,7 @@ int	ch;
 
     vs = win->w_vs;
 
-    if (finished || kbdintr) {
+    if (finished || kbdintr || ch == CTRL('C')) {
 	/*
 	 * Ensure that the window on the current buffer is
 	 * in the right place; then update the whole window.
@@ -84,6 +84,7 @@ int	ch;
 	}
 	finished = FALSE;
 	if (kbdintr) {
+	    kbdintr = FALSE;
 	    imessage = TRUE;
 	}
 	return(TRUE);

--- a/src/edit.c
+++ b/src/edit.c
@@ -81,6 +81,7 @@ int	c;
 
     if (kbdintr) {
 	    kbdintr = FALSE;
+	    imessage = TRUE;
 	    c = CTRL('C');
     }
 
@@ -103,7 +104,6 @@ int	c;
 	 */
 	switch (c) {
 	case CTRL('C'):	/* an escape or ^C ends input mode */
-	    show_message(curwin, "Interrupted");
 	    Ins_repeat = 0;
 	case ESC:
 	{
@@ -472,6 +472,7 @@ int	c;
 
     if (kbdintr) {
 	    kbdintr = FALSE;
+	    imessage = TRUE;
 	    c = CTRL('C');
     }
 
@@ -490,7 +491,6 @@ int	c;
     } else if (!literal_next) {
 	switch (c) {
 	case CTRL('C'):			/* an escape or ^C ends input mode */
-	    show_message(curwin, "Interrupted");
 	case ESC:
 	    end_replace(c);
 	    return(TRUE);

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -205,6 +205,11 @@ char	*file;
     flexnew(&cmd);
     literal = FALSE;
     while ((c = getc(fp)) != EOF) {
+	if (kbdintr) {
+	    kbdintr = FALSE;
+	    imessage = TRUE;
+	    break;
+	}
 	if (!literal && (c == CTRL('V') || c == '\n')) {
 	    switch (c) {
 	    case CTRL('V'):
@@ -212,10 +217,6 @@ char	*file;
 		break;
 
 	    case '\n':
-		if (kbdintr) {
-		    imessage = TRUE;
-		    break;
-		}
 		if (!flexempty(&cmd)) {
 		    exCommand(flexgetstr(&cmd), interactive);
 		    flexclear(&cmd);

--- a/src/normal.c
+++ b/src/normal.c
@@ -45,13 +45,12 @@ register int	c;
 
     if (kbdintr) {
 	kbdintr = FALSE;
+	imessage = TRUE;
 	c = CTRL('C');
     }
 
     switch (c) {
 	case CTRL('C'):
-	    show_message(curwin, "Interrupted");
-	    ret = TRUE;
 	case ESC:
 	    cmd->cmd_operator = NOP;
 	    cmd->cmd_prenum = 0;

--- a/src/q2tscr.c
+++ b/src/q2tscr.c
@@ -136,7 +136,6 @@ char	*argv[];
 	if (r == EOF) {
 	    if (kbdintr) {
 		event.ev_type = Ev_breakin;
-		kbdintr = FALSE;
 	    } else if (SIG_terminate) {
 		event.ev_type = Ev_terminate;
 		SIG_terminate = FALSE;

--- a/src/q2wscr.c
+++ b/src/q2wscr.c
@@ -242,7 +242,6 @@ process_event()
 	 */
 	if (kbdintr) {
 	    event.ev_type = Ev_breakin;
-	    kbdintr = FALSE;
 	} else if (SIG_terminate) {
 	    event.ev_type = Ev_terminate;
 	    SIG_terminate = FALSE;

--- a/src/tcap_scr.c
+++ b/src/tcap_scr.c
@@ -318,7 +318,6 @@ char	*argv[];
 	if (r == EOF) {
 	    if (kbdintr) {
 		event.ev_type = Ev_breakin;
-		kbdintr = FALSE;
 	    } else if (SIG_terminate) {
 		event.ev_type = Ev_terminate;
 		SIG_terminate = FALSE;

--- a/src/unix.c
+++ b/src/unix.c
@@ -216,7 +216,7 @@ kbgetc()
     static unsigned char	kbuf[48];
     static unsigned char	*kbp;
 
-    if (kbdintr == TRUE)
+    if (kbdintr)
 	return EOF;
 
     if (kb_nchars <= 0) {

--- a/src/xwnscr.c
+++ b/src/xwnscr.c
@@ -479,7 +479,6 @@ long		timeout;
 	     */
 	    if (kbdintr) {
 		xvevent->ev_type = Ev_breakin;
-		kbdintr = FALSE;
 	    } else if (SIG_terminate) {
 		xvevent->ev_type = Ev_terminate;
 		SIG_terminate = FALSE;


### PR DESCRIPTION
Stop unsetting the kbdintr flag in the main loop; only unset
it when the code actually acts on it.
Make certain that imessage flag gets set when ever the kbdintr
state gets handled.
Ensure that the 'Interrupted' message only gets printed once for
each SIGINT occurence by removing extraneous messages outside of
the xvi_handle_event routine.
Remove code that tries to second guess whether a CTRL('C') is
supposed to be a SIGINT; that should be handled by the system
specific code by converting CTRL('C') to kbdintr before it gets
out in to the general code.