### PR TITLE
Resored octal escape sequenses

### DIFF
--- a/src/ascii.c
+++ b/src/ascii.c
@@ -68,7 +68,7 @@ unsigned vischar(int c, char **p, int idx)
 		/* If Pb(P_mchars) is unset, we display non-ASCII characters
 		 * (i.e. top-bit-set characters) as hex escape sequences.
 		 **/
-		if (p) sprintf(buf, "\\x%02x", c);
+		if (p) sprintf(buf, "\\%o", c);
 		return 4;
 	} else {
 		if (p) sprintf(buf, "%c", c);


### PR DESCRIPTION
Sorry. I prefer hex escape sequences and I intended to change it back to octal before making the request. But I forgot off course.

Problem fixed. I'll be more consistent in using the test suite. :)

/cjw